### PR TITLE
Fix extra whitespace at end of execute command

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ class Action {
     _executeCommand(cmd, options) {
         console.log(`executing: [${cmd}]`)
 
+        cmd = cmd.trim()
         const INPUT = cmd.split(" "), TOOL = INPUT[0], ARGS = INPUT.slice(1)
         return spawnSync(TOOL, ARGS, options)
     }


### PR DESCRIPTION
Caused an error when publishing with symbols, as the split created an empty string at the end of the array.